### PR TITLE
Development

### DIFF
--- a/Yggdrasil.Benchmarks/Benchmarks/CoroutineManagerBenchmarks.cs
+++ b/Yggdrasil.Benchmarks/Benchmarks/CoroutineManagerBenchmarks.cs
@@ -4,7 +4,7 @@ using System.Dynamic;
 using BenchmarkDotNet.Attributes;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Benchmarks
 {
@@ -30,18 +30,18 @@ namespace Yggdrasil.Benchmarks
         public void SetupNestedParallel()
         {
             _managerA = new CoroutineManager();
-            var parallelA = new Parallel {Manager = _managerA};
-            var parallelB = new Parallel {Manager = _managerA};
-            var parallelC = new Parallel {Manager = _managerA};
+            var parallelA = new Parallel();
+            var parallelB = new Parallel();
+            var parallelC = new Parallel();
 
-            var root = new Sequence{Manager = _managerA};
-            var entryCondition = new Condition(s => ((State) s).Entry) {Manager = _managerA};
+            var root = new Sequence();
+            var entryCondition = new Condition(s => ((State) s).Entry);
 
-            var conditionalA = new TestYieldConditionNode(_managerA) {Conditional = s => s.A};
-            var conditionalB = new TestYieldConditionNode(_managerA) {Conditional = s => s.B};
-            var conditionalC = new TestYieldConditionNode(_managerA) {Conditional = s => s.C};
-            var conditionalD = new TestYieldConditionNode(_managerA) {Conditional = s => s.D};
-            var conditionalE = new TestRunningConditionNode(_managerA) {Conditional = s => s.E};
+            var conditionalA = new TestYieldConditionNode {Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {Conditional = s => s.B};
+            var conditionalC = new TestYieldConditionNode {Conditional = s => s.C};
+            var conditionalD = new TestYieldConditionNode {Conditional = s => s.D};
+            var conditionalE = new TestRunningConditionNode {Conditional = s => s.E};
 
             root.Children = new List<Node> {entryCondition, parallelA};
 
@@ -59,12 +59,12 @@ namespace Yggdrasil.Benchmarks
         public void SetupParallel()
         {
             _managerB = new CoroutineManager();
-            var root = new Parallel {Manager = _managerB};
+            var root = new Parallel();
 
-            var conditionalA = new TestYieldConditionNode(_managerB) {Conditional = s => s.A};
-            var conditionalB = new TestNestedConditionNode(_managerB) {Conditional = s => s.B};
-            var conditionalC = new TestConditionNode(_managerB) {Conditional = s => s.C};
-            var conditionalD = new TestRunningConditionNode(_managerB) {Conditional = s => s.D};
+            var conditionalA = new TestYieldConditionNode {Conditional = s => s.A};
+            var conditionalB = new TestNestedConditionNode {Conditional = s => s.B};
+            var conditionalC = new TestConditionNode {Conditional = s => s.C};
+            var conditionalD = new TestRunningConditionNode {Conditional = s => s.D};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC, conditionalD};
             _managerB.Root = root;
@@ -78,7 +78,7 @@ namespace Yggdrasil.Benchmarks
         public void SetupGenericCoroutine()
         {
             _managerC = new CoroutineManager();
-            _managerC.Root = new GenericCoroutineTestNode(_managerC);
+            _managerC.Root = new GenericCoroutineTestNode();
 
             _managerC.Initialize();
             while (_managerC.TickCount == 0) { _managerC.Update(); }
@@ -87,7 +87,7 @@ namespace Yggdrasil.Benchmarks
         public void SetupNestedCoroutine()
         {
             _managerD = new CoroutineManager();
-            _managerD.Root = new NestedCoroutineTestNode(_managerD);
+            _managerD.Root = new NestedCoroutineTestNode();
 
             _managerD.Initialize();
             while (_managerD.TickCount == 0) { _managerD.Update(); }
@@ -96,11 +96,11 @@ namespace Yggdrasil.Benchmarks
         public void SetupSequence()
         {
             _managerE = new CoroutineManager();
-            var root = new Sequence {Manager = _managerE};
+            var root = new Sequence();
 
-            var conditionalA = new TestConditionNode(_managerE) {Conditional = s => s.A};
-            var conditionalB = new TestYieldConditionNode(_managerE) {Conditional = s => s.B};
-            var conditionalC = new TestConditionNode(_managerE) {Conditional = s => s.C};
+            var conditionalA = new TestConditionNode {Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {Conditional = s => s.B};
+            var conditionalC = new TestConditionNode {Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
             _managerE.Root = root;
@@ -114,11 +114,11 @@ namespace Yggdrasil.Benchmarks
         public void SetupDynamicSequence()
         {
             _managerF = new CoroutineManager();
-            var root = new Sequence {Manager = _managerF};
+            var root = new Sequence();
 
-            var conditionalA = new TestDynamicConditionNode(_managerF) {Conditional = s => s.A};
-            var conditionalB = new TestDynamicYieldConditionNode(_managerF) {Conditional = s => s.B};
-            var conditionalC = new TestDynamicConditionNode(_managerF) {Conditional = s => s.C};
+            var conditionalA = new TestDynamicConditionNode {Conditional = s => s.A};
+            var conditionalB = new TestDynamicYieldConditionNode {Conditional = s => s.B};
+            var conditionalC = new TestDynamicConditionNode {Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
             _managerF.Root = root;
@@ -183,8 +183,6 @@ namespace Yggdrasil.Benchmarks
         {
             public Func<State, bool> Conditional;
 
-            public TestYieldConditionNode(CoroutineManager manager) { Manager = manager; }
-
             protected override async Coroutine<Result> Tick()
             {
                 await Yield;
@@ -196,8 +194,6 @@ namespace Yggdrasil.Benchmarks
         private class TestRunningConditionNode : Node
         {
             public Func<State, bool> Conditional;
-
-            public TestRunningConditionNode(CoroutineManager manager) { Manager = manager; }
 
             protected override async Coroutine<Result> Tick()
             {
@@ -215,8 +211,6 @@ namespace Yggdrasil.Benchmarks
         {
             public Func<State, bool> Conditional;
 
-            public TestConditionNode(CoroutineManager manager) { Manager = manager; }
-
             protected override Coroutine<Result> Tick()
             {
                 return Conditional((State) State) ? Success : Failure;
@@ -226,8 +220,6 @@ namespace Yggdrasil.Benchmarks
         private class TestNestedConditionNode : Node
         {
             public Func<State, bool> Conditional;
-
-            public TestNestedConditionNode(CoroutineManager manager) { Manager = manager; }
 
             protected override async Coroutine<Result> Tick()
             {
@@ -253,8 +245,6 @@ namespace Yggdrasil.Benchmarks
 
         private class GenericCoroutineTestNode : Node
         {
-            public GenericCoroutineTestNode(CoroutineManager manager) { Manager = manager; }
-
             protected override async Coroutine<Result> Tick()
             {
                 await Yield;
@@ -298,8 +288,6 @@ namespace Yggdrasil.Benchmarks
 
         private class NestedCoroutineTestNode : Node
         {
-            public NestedCoroutineTestNode(CoroutineManager manager) { Manager = manager; }
-
             protected override async Coroutine<Result> Tick()
             {
                 await Yield;
@@ -353,8 +341,6 @@ namespace Yggdrasil.Benchmarks
         {
             public Func<dynamic, bool> Conditional;
 
-            public TestDynamicConditionNode(CoroutineManager manager) { Manager = manager; }
-
             protected override Coroutine<Result> Tick()
             {
                 return Conditional(State) ? Success : Failure;
@@ -364,8 +350,6 @@ namespace Yggdrasil.Benchmarks
         private class TestDynamicYieldConditionNode : Node
         {
             public Func<dynamic, bool> Conditional;
-
-            public TestDynamicYieldConditionNode(CoroutineManager manager) { Manager = manager; }
 
             protected override async Coroutine<Result> Tick()
             {

--- a/Yggdrasil.Benchmarks/Benchmarks/CoroutineManagerBenchmarks.cs
+++ b/Yggdrasil.Benchmarks/Benchmarks/CoroutineManagerBenchmarks.cs
@@ -12,7 +12,7 @@ namespace Yggdrasil.Benchmarks
     [MemoryDiagnoser]
     public class CoroutineManagerBenchmarks
     {
-        private CoroutineManager _managerA, _managerB, _managerC, _managerD, _managerE, _managerF;
+        private BehaviourTree _treeA, _treeB, _treeC, _treeD, _treeE, _treeF;
         private State _stateA, _stateB, _stateE;
         private object _dynamicStateA;
 
@@ -29,7 +29,6 @@ namespace Yggdrasil.Benchmarks
 
         public void SetupNestedParallel()
         {
-            _managerA = new CoroutineManager();
             var parallelA = new Parallel();
             var parallelB = new Parallel();
             var parallelC = new Parallel();
@@ -49,16 +48,14 @@ namespace Yggdrasil.Benchmarks
             parallelB.Children = new List<Node> {conditionalB, conditionalC};
             parallelC.Children = new List<Node> {conditionalD, conditionalE};
 
-            _managerA.Root = root;
+            _treeA = new BehaviourTree(root);
             _stateA = new State {Entry = true, A = true, B = true, C = true, D = true, E = true};
 
-            _managerA.Initialize();
-            while (_managerA.TickCount == 0) { _managerA.Update(_stateA); }
+            while (_treeA.TickCount == 0) { _treeA.Update(_stateA); }
         }
 
         public void SetupParallel()
         {
-            _managerB = new CoroutineManager();
             var root = new Parallel();
 
             var conditionalA = new TestYieldConditionNode {Conditional = s => s.A};
@@ -67,35 +64,29 @@ namespace Yggdrasil.Benchmarks
             var conditionalD = new TestRunningConditionNode {Conditional = s => s.D};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC, conditionalD};
-            _managerB.Root = root;
+            _treeB = new BehaviourTree(root);
 
             _stateB = new State {A = true, B = false, C = true, D = false};
 
-            _managerB.Initialize();
-            while (_managerB.TickCount == 0) { _managerB.Update(_stateB); }
+            while (_treeB.TickCount == 0) { _treeB.Update(_stateB); }
         }
 
         public void SetupGenericCoroutine()
         {
-            _managerC = new CoroutineManager();
-            _managerC.Root = new GenericCoroutineTestNode();
+            _treeC = new BehaviourTree(new GenericCoroutineTestNode());
 
-            _managerC.Initialize();
-            while (_managerC.TickCount == 0) { _managerC.Update(); }
+            while (_treeC.TickCount == 0) { _treeC.Update(); }
         }
 
         public void SetupNestedCoroutine()
         {
-            _managerD = new CoroutineManager();
-            _managerD.Root = new NestedCoroutineTestNode();
+            _treeD = new BehaviourTree(new NestedCoroutineTestNode());
 
-            _managerD.Initialize();
-            while (_managerD.TickCount == 0) { _managerD.Update(); }
+            while (_treeD.TickCount == 0) { _treeD.Update(); }
         }
 
         public void SetupSequence()
         {
-            _managerE = new CoroutineManager();
             var root = new Sequence();
 
             var conditionalA = new TestConditionNode {Conditional = s => s.A};
@@ -103,17 +94,15 @@ namespace Yggdrasil.Benchmarks
             var conditionalC = new TestConditionNode {Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
-            _managerE.Root = root;
+            _treeE = new BehaviourTree(root);
 
             _stateE = new State {A = true, B = true, C = true};
 
-            _managerE.Initialize();
-            while (_managerE.TickCount == 0) { _managerE.Update(_stateE); }
+            while (_treeE.TickCount == 0) { _treeE.Update(_stateE); }
         }
 
         public void SetupDynamicSequence()
         {
-            _managerF = new CoroutineManager();
             var root = new Sequence();
 
             var conditionalA = new TestDynamicConditionNode {Conditional = s => s.A};
@@ -121,7 +110,7 @@ namespace Yggdrasil.Benchmarks
             var conditionalC = new TestDynamicConditionNode {Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
-            _managerF.Root = root;
+            _treeF = new BehaviourTree(root);
 
             dynamic state = new ExpandoObject();
             state.A = true;
@@ -129,44 +118,43 @@ namespace Yggdrasil.Benchmarks
             state.C = true;
             _dynamicStateA = state;
 
-            _managerF.Initialize();
-            while (_managerF.TickCount == 0) { _managerF.Update(_dynamicStateA); }
+            while (_treeF.TickCount == 0) { _treeF.Update(_dynamicStateA); }
         }
 
         [Benchmark]
         public void BNestedParallel()
         {
-            while (_managerA.TickCount == 1) { _managerA.Update(_stateA); }
+            while (_treeA.TickCount == 1) { _treeA.Update(_stateA); }
         }
 
         [Benchmark]
         public void BParallel()
         {
-            while (_managerB.TickCount == 1) { _managerB.Update(_stateB); }
+            while (_treeB.TickCount == 1) { _treeB.Update(_stateB); }
         }
 
         [Benchmark]
         public void BGenericCoroutine()
         {
-            while (_managerC.TickCount == 1) { _managerC.Update(); }
+            while (_treeC.TickCount == 1) { _treeC.Update(); }
         }
 
         [Benchmark]
         public void BNestedCoroutine()
         {
-            while (_managerD.TickCount == 1) { _managerD.Update(); }
+            while (_treeD.TickCount == 1) { _treeD.Update(); }
         }
 
         [Benchmark]
         public void BSequence()
         {
-            while (_managerE.TickCount == 1) { _managerE.Update(_stateE); }
+            while (_treeE.TickCount == 1) { _treeE.Update(_stateE); }
         }
 
         [Benchmark]
         public void BDynamicSequence()
         {
-            while (_managerF.TickCount == 1) { _managerF.Update(_dynamicStateA); }
+            while (_treeF.TickCount == 1) { _treeF.Update(_dynamicStateA); }
         }
 
         private class State

--- a/Yggdrasil.Benchmarks/Benchmarks/ScriptBenchmarks.cs
+++ b/Yggdrasil.Benchmarks/Benchmarks/ScriptBenchmarks.cs
@@ -14,7 +14,7 @@ namespace Yggdrasil.Benchmarks
     [MemoryDiagnoser]
     public class ScriptBenchmarks
     {
-        private CoroutineManager _manager;
+        private BehaviourTree _tree;
         private TestState _state;
 
         [GlobalSetup]
@@ -31,13 +31,11 @@ namespace Yggdrasil.Benchmarks
             var context = parser.BuildFromFiles<TestState>(scriptPath);
             if (context.Errors.Count > 0) { throw new Exception(context.Errors[0].Message); }
 
-            _manager = new CoroutineManager();
-            _manager.Root = context.Instantiate("root", _manager);
-            _manager.Initialize();
+            _tree = new BehaviourTree(context.Instantiate("root"));
             _state = new TestState();
 
             // Warmup.
-            while (_manager.TickCount == 0) { _manager.Update(_state); }
+            while (_tree.TickCount == 0) { _tree.Update(_state); }
 
             _state = new TestState();
         }
@@ -45,12 +43,12 @@ namespace Yggdrasil.Benchmarks
         [Benchmark]
         public void Execute()
         {
-            _manager.Update(_state);
-            _manager.Update(_state);
-            _manager.Update(_state);
-            _manager.Update(_state);
-            _manager.Update(_state);
-            _manager.Update(_state);
+            _tree.Update(_state);
+            _tree.Update(_state);
+            _tree.Update(_state);
+            _tree.Update(_state);
+            _tree.Update(_state);
+            _tree.Update(_state);
         }
 
         public class TestState

--- a/Yggdrasil.Benchmarks/Benchmarks/ScriptBenchmarks.cs
+++ b/Yggdrasil.Benchmarks/Benchmarks/ScriptBenchmarks.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Attributes;
 using Yggdrasil.Attributes;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 using Yggdrasil.Scripting;
 
 namespace Yggdrasil.Benchmarks

--- a/Yggdrasil.Benchmarks/Program.cs
+++ b/Yggdrasil.Benchmarks/Program.cs
@@ -7,14 +7,9 @@ namespace Yggdrasil.Benchmarks
     {
         public static void Main(string[] args)
         {
-            var benchmark = new ScriptBenchmarks();
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
-            benchmark.Setup();
-            benchmark.Execute();
-
-            //BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-
-            //Console.ReadLine();
+            Console.ReadLine();
         }
     }
 }

--- a/Yggdrasil.Benchmarks/Program.cs
+++ b/Yggdrasil.Benchmarks/Program.cs
@@ -7,9 +7,14 @@ namespace Yggdrasil.Benchmarks
     {
         public static void Main(string[] args)
         {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+            var benchmark = new ScriptBenchmarks();
 
-            Console.ReadLine();
+            benchmark.Setup();
+            benchmark.Execute();
+
+            //BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+            //Console.ReadLine();
         }
     }
 }

--- a/Yggdrasil.Scripting/BehaviourTreeDefinition.cs
+++ b/Yggdrasil.Scripting/BehaviourTreeDefinition.cs
@@ -29,7 +29,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Yggdrasil.Coroutines;
 using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Scripting
@@ -47,7 +46,7 @@ namespace Yggdrasil.Scripting
 
         public List<ParserNode> ParserNodes { get; set; } = new List<ParserNode>();
 
-        public Node Instantiate(string guid, CoroutineManager manager)
+        public Node Instantiate(string guid)
         {
             var parserNode = ParserNodes.FirstOrDefault(p => p.Guid == guid);
 
@@ -86,6 +85,11 @@ namespace Yggdrasil.Scripting
                     next.Instance.Children.Add(instance);
                     open.Push(c);
                 }
+            }
+
+            foreach (var node in root.DepthFirstIterate())
+            {
+                node?.Initialize();
             }
 
             return root;

--- a/Yggdrasil.Scripting/BehaviourTreeDefinition.cs
+++ b/Yggdrasil.Scripting/BehaviourTreeDefinition.cs
@@ -30,7 +30,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Yggdrasil.Coroutines;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Scripting
 {
@@ -60,7 +60,7 @@ namespace Yggdrasil.Scripting
             }
 
             // Uses a depth first loop instead of recursion to avoid potential stack overflows.
-            var root = parserNode.CreateInstance(manager, TypeDefMap, Errors);
+            var root = parserNode.CreateInstance(TypeDefMap, Errors);
             var n = new InstantiationNode {Instance = root, Parser = parserNode};
             var open = new Stack<InstantiationNode>();
 
@@ -76,7 +76,7 @@ namespace Yggdrasil.Scripting
 
                 foreach (var parserChild in children)
                 {
-                    var instance = parserChild.CreateInstance(manager, TypeDefMap, Errors);
+                    var instance = parserChild.CreateInstance(TypeDefMap, Errors);
                     if (instance == null) { continue; }
 
                     var c = new InstantiationNode {Instance = instance, Parser = parserChild};

--- a/Yggdrasil.Scripting/ParserErrorHelper.cs
+++ b/Yggdrasil.Scripting/ParserErrorHelper.cs
@@ -28,7 +28,7 @@
 #endregion
 
 using System.Collections.Generic;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Scripting
 {

--- a/Yggdrasil.Scripting/ParserNode.cs
+++ b/Yggdrasil.Scripting/ParserNode.cs
@@ -31,8 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Serialization;
-using Yggdrasil.Coroutines;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Scripting
 {
@@ -51,16 +50,15 @@ namespace Yggdrasil.Scripting
         public ParserNode TypeDef;
         public XmlNode Xml;
 
-        public Node CreateInstance(CoroutineManager manager, Dictionary<string, ParserNode> typeDefMap,
+        public Node CreateInstance(Dictionary<string, ParserNode> typeDefMap,
             List<BuildError> errors)
         {
             return IsDerivedFromTypeDef
-                ? CreateTypeDefInstance(manager, typeDefMap, errors)
-                : CreateStaticTypeInstance(manager, typeDefMap, errors);
+                ? CreateTypeDefInstance(typeDefMap, errors)
+                : CreateStaticTypeInstance(errors);
         }
 
-        private Node CreateTypeDefInstance(CoroutineManager manager, Dictionary<string, ParserNode> typeDefMap,
-            List<BuildError> errors)
+        private Node CreateTypeDefInstance(Dictionary<string, ParserNode> typeDefMap, List<BuildError> errors)
         {
             // Find the TypeDef parser node.
             if (!typeDefMap.TryGetValue(Tag, out var parserDef))
@@ -70,11 +68,10 @@ namespace Yggdrasil.Scripting
             }
 
             // Create an instance from the TypeDef parser node.
-            var instance = parserDef.CreateInstance(manager, typeDefMap, errors);
+            var instance = parserDef.CreateInstance(typeDefMap, errors);
             if (instance == null) { return null; }
 
             // Set manager and guid.
-            instance.Manager = manager;
             instance.Guid = Guid;
 
             // Set function values.
@@ -85,8 +82,7 @@ namespace Yggdrasil.Scripting
             return instance;
         }
 
-        private Node CreateStaticTypeInstance(CoroutineManager manager, Dictionary<string, ParserNode> typeDefMap,
-            List<BuildError> errors)
+        private Node CreateStaticTypeInstance(List<BuildError> errors)
         {
             // Create an instance using reflection.
             Node instance;
@@ -109,7 +105,6 @@ namespace Yggdrasil.Scripting
             }
 
             // Set manager and guid.
-            instance.Manager = manager;
             instance.Guid = Guid;
 
             // Set function values.

--- a/Yggdrasil.Scripting/YggParser.cs
+++ b/Yggdrasil.Scripting/YggParser.cs
@@ -35,7 +35,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Yggdrasil.Attributes;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Scripting
 {
@@ -122,7 +122,7 @@ namespace Yggdrasil.Scripting
             // Instantiate nodes once to test them.
             foreach (var parserNode in context.ParserNodes.Where(p => p.IsTopmost))
             {
-                var node = parserNode.CreateInstance(null, context.TypeDefMap, context.Errors);
+                var node = parserNode.CreateInstance(context.TypeDefMap, context.Errors);
                 if (context.Errors.Any(e => e.IsCritical)) { return context; }
 
                 if (node != null) { context.TopmostNodeCount += 1; }

--- a/Yggdrasil.Tests/AsyncFlowTests.cs
+++ b/Yggdrasil.Tests/AsyncFlowTests.cs
@@ -13,33 +13,33 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void ContinuationOrderTest()
         {
-            var manager = new CoroutineManager();
             var node = new TestNode();
             var stages = new Queue<string>();
 
             node.Stages = stages;
-            manager.Root = node;
+
+            var tree = new BehaviourTree(node);
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             var sequence = new List<string> { "TICK", "1A", "2A" };
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "2B", "3A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B", "2C: TRUE", "1B: 10"});
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "1C"});
             Assert.IsTrue(stages.SequenceEqual(sequence));
@@ -95,33 +95,33 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void NestedCoroutinesTest()
         {
-            var manager = new CoroutineManager();
             var node = new NestedCoroutinesTestNode();
             var stages = new Queue<string>();
 
             node.Stages = stages;
-            manager.Root = node;
+
+            var tree = new BehaviourTree(node);
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             var sequence = new List<string> { "TICK", "1A", "3A: 5" };
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B: 7", "1B", "2A"});
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "2B", "1C: 10", "3A: 10" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B: 12", "1D"});
             Assert.IsTrue(stages.SequenceEqual(sequence));
@@ -178,69 +178,69 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void ContinuationLoopTest()
         {
-            var manager = new CoroutineManager();
             var node = new LoopTestNode();
             var stages = new Queue<string>();
 
             node.Stages = stages;
-            manager.Root = node;
+
+            var tree = new BehaviourTree(node);
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             var sequence = new List<string> { "TICK", "1A", "2A" };
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "2B", "3A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B", "2Loop: TRUE", "3A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B", "2Loop: FALSE", "3A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B", "2Loop: TRUE", "2C", "1Loop: 1", "2A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "2B", "3A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B", "2Loop: TRUE", "3A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B", "2Loop: FALSE", "3A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new[] { "TICK", "3B", "2Loop: TRUE", "2C", "1Loop: 2", "1C" });
             Assert.IsTrue(stages.SequenceEqual(sequence));
 
             stages.Enqueue("TICK");
-            manager.Update();
+            tree.Update();
 
             sequence.AddRange(new List<string> { "TICK", "1A", "2A" });
             Assert.IsTrue(stages.SequenceEqual(sequence));

--- a/Yggdrasil.Tests/AsyncFlowTests.cs
+++ b/Yggdrasil.Tests/AsyncFlowTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Tests
 {
@@ -14,7 +14,7 @@ namespace Yggdrasil.Tests
         public void ContinuationOrderTest()
         {
             var manager = new CoroutineManager();
-            var node = new TestNode(manager);
+            var node = new TestNode();
             var stages = new Queue<string>();
 
             node.Stages = stages;
@@ -48,8 +48,6 @@ namespace Yggdrasil.Tests
         private class TestNode : Node
         {
             public Queue<string> Stages;
-
-            public TestNode(CoroutineManager manager) { Manager = manager; }
 
             protected override async Coroutine<Result> Tick()
             {
@@ -98,7 +96,7 @@ namespace Yggdrasil.Tests
         public void NestedCoroutinesTest()
         {
             var manager = new CoroutineManager();
-            var node = new NestedCoroutinesTestNode(manager);
+            var node = new NestedCoroutinesTestNode();
             var stages = new Queue<string>();
 
             node.Stages = stages;
@@ -132,8 +130,6 @@ namespace Yggdrasil.Tests
         private class NestedCoroutinesTestNode : Node
         {
             public Queue<string> Stages;
-
-            public NestedCoroutinesTestNode(CoroutineManager manager) { Manager = manager; }
 
             protected override async Coroutine<Result> Tick()
             {
@@ -183,7 +179,7 @@ namespace Yggdrasil.Tests
         public void ContinuationLoopTest()
         {
             var manager = new CoroutineManager();
-            var node = new LoopTestNode(manager);
+            var node = new LoopTestNode();
             var stages = new Queue<string>();
 
             node.Stages = stages;
@@ -253,8 +249,6 @@ namespace Yggdrasil.Tests
         private class LoopTestNode : Node
         {
             public Queue<string> Stages;
-
-            public LoopTestNode(CoroutineManager manager) { Manager = manager; }
 
             protected override async Coroutine<Result> Tick()
             {

--- a/Yggdrasil.Tests/CompilerTests.cs
+++ b/Yggdrasil.Tests/CompilerTests.cs
@@ -4,7 +4,7 @@ using System.Dynamic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 using Yggdrasil.Scripting;
 
 namespace Yggdrasil.Tests

--- a/Yggdrasil.Tests/CoroutinePoolingTests.cs
+++ b/Yggdrasil.Tests/CoroutinePoolingTests.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yggdrasil.Behaviour;
+using Yggdrasil.Coroutines;
+using Yggdrasil.Enums;
+
+namespace Yggdrasil.Tests
+{
+    [TestClass]
+    public class CoroutinePoolingTests
+    {
+        [TestMethod]
+        public void CorouinePoolLeakTest()
+        {
+            var stages = new Queue<string>();
+            var sequence = new List<string>();
+
+            var parallelA = new Parallel();
+            var parallelB = new Parallel();
+            var parallelC = new Parallel();
+
+            var root = new Sequence();
+            var entryCondition = new Condition(s => ((State) s).Entry);
+
+            var conditionalA = new TestYieldConditionNode {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
+            var conditionalC = new TestYieldConditionNode {PrintA="CYield", PrintB="C", Stages = stages, Conditional = s => s.C};
+            var conditionalD = new TestYieldConditionNode {PrintA="DYield", PrintB="D", Stages = stages, Conditional = s => s.D};
+            var conditionalE = new TestRunningConditionNode {PrintA="E", Stages = stages, Conditional = s => s.E};
+
+            parallelA.Children = new List<Node> {parallelB, parallelC, conditionalA};
+            parallelB.Children = new List<Node> {conditionalB, conditionalC};
+            parallelC.Children = new List<Node> {conditionalD, conditionalE};
+
+            root.Children = new List<Node> {entryCondition, parallelA};
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
+
+            var manager = new BehaviourTree(root);
+
+            Coroutine<Result>.Pool.Clear();
+            Coroutine.Pool.Clear();
+
+            TickOnce(manager, stages, sequence);
+
+            var genericPoolCount = Coroutine<Result>.Pool.Count;
+            var voidPoolCount = Coroutine.Pool.Count;
+
+            for (var i = 0; i < 100; i++)
+            {
+                TickOnce(manager, stages, sequence);
+
+                Assert.IsTrue(Coroutine<Result>.Pool.Count > 0);
+                Assert.IsTrue(Coroutine.Pool.Count > 0);
+                Assert.AreEqual(genericPoolCount, Coroutine<Result>.Pool.Count);
+                Assert.AreEqual(voidPoolCount, Coroutine.Pool.Count);
+            }
+        }
+
+        private static void TickOnce(BehaviourTree manager, Queue<string> stages, List<string> sequence)
+        {
+            var initialTick = manager.TickCount;
+
+            stages.Enqueue("TICK");
+            sequence.AddRange(new[] {"TICK", "AYield", "BYield", "CYield", "DYield"});
+            manager.Update(new State {Entry = true, A = true, B = true, C = true, D = true, E = true});
+
+            Assert.AreEqual(Result.Unknown, manager.Result);
+            Assert.IsTrue(stages.SequenceEqual(sequence));
+
+            stages.Enqueue("TICK");
+            sequence.AddRange(new[] {"TICK", "A", "B", "C", "D"});
+            manager.Update(new State {Entry = true, A = true, B = true, C = true, D = true, E = true});
+
+            Assert.AreEqual(Result.Unknown, manager.Result);
+            Assert.IsTrue(stages.SequenceEqual(sequence));
+
+            stages.Enqueue("TICK");
+            sequence.AddRange(new[] {"TICK"});
+            manager.Update(new State {Entry = true, A = true, B = true, C = true, D = true, E = true});
+
+            Assert.AreEqual(Result.Unknown, manager.Result);
+            Assert.IsTrue(stages.SequenceEqual(sequence));
+
+            stages.Enqueue("TICK");
+            sequence.AddRange(new[] {"TICK"});
+            manager.Update(new State {Entry = true, A = true, B = true, C = true, D = true, E = true});
+
+            Assert.AreEqual(Result.Unknown, manager.Result);
+            Assert.IsTrue(stages.SequenceEqual(sequence));
+
+            stages.Enqueue("TICK");
+            sequence.AddRange(new[] {"TICK"});
+            manager.Update(new State {Entry = true, A = true, B = true, C = true, D = true, E = true});
+
+            Assert.AreEqual(Result.Unknown, manager.Result);
+            Assert.IsTrue(stages.SequenceEqual(sequence));
+
+            stages.Enqueue("TICK");
+            sequence.AddRange(new[] {"TICK", "E"});
+            manager.Update(new State {Entry = true, A = true, B = true, C = true, D = true, E = true});
+
+            Assert.AreEqual(Result.Success, manager.Result);
+            Assert.IsTrue(stages.SequenceEqual(sequence));
+            Assert.AreEqual(initialTick + 1UL, manager.TickCount);
+
+            stages.Clear();
+            sequence.Clear();
+        }
+
+        private class State
+        {
+            public bool Entry;
+            public bool A;
+            public bool B;
+            public bool C;
+            public bool D;
+            public bool E;
+        }
+
+        private class TestYieldConditionNode : Node
+        {
+            public string PrintA;
+            public string PrintB;
+
+            public Queue<string> Stages;
+
+            public Func<State, bool> Conditional;
+
+            protected override async Coroutine<Result> Tick()
+            {
+                Stages.Enqueue(PrintA);
+
+                await Yield;
+
+                Stages.Enqueue(PrintB);
+
+                return Conditional((State) State) ? Result.Success : Result.Failure;
+            }
+        }
+
+        private class TestRunningConditionNode : Node
+        {
+            public string PrintA;
+
+            public Queue<string> Stages;
+
+            public Func<State, bool> Conditional;
+
+            protected override async Coroutine<Result> Tick()
+            {
+                await Yield;
+                await Yield;
+                await Yield;
+                await MethodA();
+
+                Stages.Enqueue(PrintA);
+
+                return Conditional((State) State) ? Result.Success : Result.Failure;
+            }
+
+            private async Coroutine MethodA()
+            {
+                await Yield;
+                await MethodB();
+            }
+
+            private async Coroutine MethodB()
+            {
+                await Yield;
+            }
+        }
+    }
+}

--- a/Yggdrasil.Tests/ExternalTaskTests.cs
+++ b/Yggdrasil.Tests/ExternalTaskTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Yggdrasil.Behaviour;
+using Yggdrasil.Coroutines;
+using Yggdrasil.Enums;
+using Parallel = Yggdrasil.Behaviour.Parallel;
+
+namespace Yggdrasil.Tests
+{
+    [TestClass]
+    public class ExternalTaskTests
+    {
+        [TestMethod]
+        public void AsynchronousTaskTest()
+        {
+            var stages = new Queue<string>();
+
+            var parallelA = new Parallel();
+            var parallelB = new Parallel();
+            var parallelC = new Parallel();
+
+            var root = new Sequence();
+            var entryCondition = new Condition(s => ((State) s).Entry);
+
+            var conditionalA = new TestYieldConditionNode {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
+            var conditionalC = new TestYieldConditionNode {PrintA="CYield", PrintB="C", Stages = stages, Conditional = s => s.C};
+            var conditionalD = new TestYieldConditionNode {PrintA="DYield", PrintB="D", Stages = stages, Conditional = s => s.D};
+            var conditionalE = new TestRunningConditionNode {PrintA="E", Stages = stages, Conditional = s => s.E};
+
+            parallelA.Children = new List<Node> {parallelB, parallelC, conditionalA};
+            parallelB.Children = new List<Node> {conditionalB, conditionalC};
+            parallelC.Children = new List<Node> {conditionalD, conditionalE};
+
+            root.Children = new List<Node> {entryCondition, parallelA};
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
+
+            var manager = new BehaviourTree(root);
+            var state = new State {Entry = true, A = true, B = true, C = true, D = true, E = true};
+
+            for (var i = 0; i < 2; i++)
+            {
+                var sequence = new[] {"AYield", "BYield", "CYield", "DYield"};
+                var initialTick = manager.TickCount;
+
+                while (initialTick == manager.TickCount) { manager.Update(state); }
+
+                Assert.AreEqual(Result.Success, manager.Result);
+                Assert.AreEqual(initialTick + 1UL, manager.TickCount);
+                Assert.IsTrue(stages.Take(4).SequenceEqual(sequence));
+                Assert.IsTrue(stages.Any(s => s == "A"));
+                Assert.IsTrue(stages.Any(s => s == "B"));
+                Assert.IsTrue(stages.Any(s => s == "C"));
+                Assert.IsTrue(stages.Any(s => s == "D"));
+
+                stages.Clear();
+            }
+        }
+
+        private class State
+        {
+            public bool Entry;
+            public bool A;
+            public bool B;
+            public bool C;
+            public bool D;
+            public bool E;
+        }
+
+        private class TestYieldConditionNode : Node
+        {
+            public string PrintA;
+            public string PrintB;
+
+            public Queue<string> Stages;
+
+            public Func<State, bool> Conditional;
+
+            protected override async Coroutine<Result> Tick()
+            {
+                Stages.Enqueue(PrintA);
+
+                await Yield;
+
+                var print = await RunAsync(Task.Run(async () =>
+                {
+                    await Task.Delay(100);
+                    return PrintB;
+                }));
+
+                Stages.Enqueue(print);
+
+                return Conditional((State) State) ? Result.Success : Result.Failure;
+            }
+        }
+
+        private class TestRunningConditionNode : Node
+        {
+            public string PrintA;
+
+            public Queue<string> Stages;
+
+            public Func<State, bool> Conditional;
+
+            protected override async Coroutine<Result> Tick()
+            {
+                await Yield;
+                await Yield;
+                await Yield;
+                await MethodA();
+
+                Stages.Enqueue(PrintA);
+
+                return Conditional((State) State) ? Result.Success : Result.Failure;
+            }
+
+            private async Coroutine MethodA()
+            {
+                await Yield;
+                await MethodB();
+            }
+
+            private async Coroutine MethodB()
+            {
+                await Yield;
+            }
+        }
+    }
+}

--- a/Yggdrasil.Tests/NodeTests.cs
+++ b/Yggdrasil.Tests/NodeTests.cs
@@ -14,17 +14,17 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void SequenceNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Sequence();
             var stages = new Queue<string>();
-
-            manager.Root = root;
 
             var conditionalA = new TestConditionNode {Print="A", Stages = stages, Conditional = s => s.A};
             var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
             var conditionalC = new TestConditionNode {Print="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
+
+            var manager = new BehaviourTree(root);
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -95,17 +95,16 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void ConditionNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Sequence();
             var stages = new Queue<string>();
-
-            manager.Root = root;
+            var manager = new BehaviourTree(root);
 
             var conditionalA = new TestConditionNode {Print="A", Stages = stages, Conditional = s => s.A};
             var conditionalB = new Condition(s => ((State) s).B);
             var conditionalC = new TestConditionNode {Print="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -131,17 +130,16 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void SelectorNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Selector();
             var stages = new Queue<string>();
-
-            manager.Root = root;
+            var manager = new BehaviourTree(root);
 
             var conditionalA = new TestConditionNode {Print="A", Stages = stages, Conditional = s => s.A};
             var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
             var conditionalC = new TestConditionNode {Print="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -216,12 +214,12 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void InverterNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Inverter();
             var stages = new Queue<string>();
+            var manager = new BehaviourTree(root);
 
-            manager.Root = root;
             root.Children.Add(new TestYieldConditionNode() {PrintA="Yield", PrintB="A", Stages = stages, Conditional = s => s.A});
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -267,13 +265,13 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void FilterNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Filter();
             var stages = new Queue<string>();
+            var manager = new BehaviourTree(root);
 
             root.Conditional = s => ((State) s).A;
             root.Children.Add(new TestYieldConditionNode {PrintA="Yield", PrintB="B", Stages = stages, Conditional = s => s.B});
-            manager.Root = root;
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -310,17 +308,16 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void NestedCoroutinesNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Sequence();
             var stages = new Queue<string>();
-
-            manager.Root = root;
+            var manager = new BehaviourTree(root);
 
             var conditionalA = new TestConditionNode {Print="A0", Stages = stages, Conditional = s => s.A};
             var conditionalB = new TestNestedConditionNode {Stages = stages, Conditional = s => s.B};
             var conditionalC = new TestConditionNode {Print="C0", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -347,16 +344,16 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void ParallelNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Parallel();
             var stages = new Queue<string>();
+            var manager = new BehaviourTree(root);
 
             var conditionalA = new TestYieldConditionNode {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
             var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
             var conditionalC = new TestYieldConditionNode {PrintA="CYield", PrintB="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
-            manager.Root = root;
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -421,15 +418,15 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void ParallelFilterNodeTest()
         {
-            var manager = new CoroutineManager();
             var root = new Interrupt(s => ((State)s).C);
             var stages = new Queue<string>();
+            var manager = new BehaviourTree(root);
 
             var conditionalA = new TestYieldConditionNode {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
             var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
             
             root.Children = new List<Node> {conditionalA, conditionalB};
-            manager.Root = root;
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -485,7 +482,6 @@ namespace Yggdrasil.Tests
         [TestMethod]
         public void NestedParallelNodeTest()
         {
-            var manager = new CoroutineManager();
             var stages = new Queue<string>();
 
             var parallelA = new Parallel();
@@ -501,14 +497,14 @@ namespace Yggdrasil.Tests
             var conditionalD = new TestYieldConditionNode {PrintA="DYield", PrintB="D", Stages = stages, Conditional = s => s.D};
             var conditionalE = new TestRunningConditionNode {PrintA="E", Stages = stages, Conditional = s => s.E};
 
-            root.Children = new List<Node> {entryCondition, parallelA};
-
             parallelA.Children = new List<Node> {parallelB, parallelC, conditionalA};
             parallelB.Children = new List<Node> {conditionalB, conditionalC};
             parallelC.Children = new List<Node> {conditionalD, conditionalE};
 
-            manager.Root = root;
+            root.Children = new List<Node> {entryCondition, parallelA};
+            foreach (var n in root.DepthFirstIterate()) { n.Initialize(); }
 
+            var manager = new BehaviourTree(root);
             var sequence = new List<string>();
 
             for (var i = 0; i < 2; i++)

--- a/Yggdrasil.Tests/NodeTests.cs
+++ b/Yggdrasil.Tests/NodeTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Tests
 {
@@ -15,14 +15,14 @@ namespace Yggdrasil.Tests
         public void SequenceNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Sequence {Manager = manager};
+            var root = new Sequence();
             var stages = new Queue<string>();
 
             manager.Root = root;
 
-            var conditionalA = new TestConditionNode(manager) {Print="A", Stages = stages, Conditional = s => s.A};
-            var conditionalB = new TestYieldConditionNode(manager) {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
-            var conditionalC = new TestConditionNode(manager) {Print="C", Stages = stages, Conditional = s => s.C};
+            var conditionalA = new TestConditionNode {Print="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
+            var conditionalC = new TestConditionNode {Print="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
 
@@ -96,14 +96,14 @@ namespace Yggdrasil.Tests
         public void ConditionNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Sequence {Manager = manager};
+            var root = new Sequence();
             var stages = new Queue<string>();
 
             manager.Root = root;
 
-            var conditionalA = new TestConditionNode(manager) {Print="A", Stages = stages, Conditional = s => s.A};
-            var conditionalB = new Condition(s => ((State) s).B){Manager = manager};
-            var conditionalC = new TestConditionNode(manager) {Print="C", Stages = stages, Conditional = s => s.C};
+            var conditionalA = new TestConditionNode {Print="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new Condition(s => ((State) s).B);
+            var conditionalC = new TestConditionNode {Print="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
 
@@ -132,14 +132,14 @@ namespace Yggdrasil.Tests
         public void SelectorNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Selector{Manager = manager};
+            var root = new Selector();
             var stages = new Queue<string>();
 
             manager.Root = root;
 
-            var conditionalA = new TestConditionNode(manager) {Print="A", Stages = stages, Conditional = s => s.A};
-            var conditionalB = new TestYieldConditionNode(manager) {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
-            var conditionalC = new TestConditionNode(manager) {Print="C", Stages = stages, Conditional = s => s.C};
+            var conditionalA = new TestConditionNode {Print="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
+            var conditionalC = new TestConditionNode {Print="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
 
@@ -217,11 +217,11 @@ namespace Yggdrasil.Tests
         public void InverterNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Inverter{Manager = manager};
+            var root = new Inverter();
             var stages = new Queue<string>();
 
             manager.Root = root;
-            root.Children.Add(new TestYieldConditionNode(manager) {PrintA="Yield", PrintB="A", Stages = stages, Conditional = s => s.A});
+            root.Children.Add(new TestYieldConditionNode() {PrintA="Yield", PrintB="A", Stages = stages, Conditional = s => s.A});
 
             Assert.AreEqual(0UL, manager.TickCount);
 
@@ -268,11 +268,11 @@ namespace Yggdrasil.Tests
         public void FilterNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Filter{Manager = manager};
+            var root = new Filter();
             var stages = new Queue<string>();
 
             root.Conditional = s => ((State) s).A;
-            root.Children.Add(new TestYieldConditionNode(manager) {PrintA="Yield", PrintB="B", Stages = stages, Conditional = s => s.B});
+            root.Children.Add(new TestYieldConditionNode {PrintA="Yield", PrintB="B", Stages = stages, Conditional = s => s.B});
             manager.Root = root;
 
             Assert.AreEqual(0UL, manager.TickCount);
@@ -311,14 +311,14 @@ namespace Yggdrasil.Tests
         public void NestedCoroutinesNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Sequence{Manager = manager};
+            var root = new Sequence();
             var stages = new Queue<string>();
 
             manager.Root = root;
 
-            var conditionalA = new TestConditionNode(manager) {Print="A0", Stages = stages, Conditional = s => s.A};
-            var conditionalB = new TestNestedConditionNode(manager) {Stages = stages, Conditional = s => s.B};
-            var conditionalC = new TestConditionNode(manager) {Print="C0", Stages = stages, Conditional = s => s.C};
+            var conditionalA = new TestConditionNode {Print="A0", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestNestedConditionNode {Stages = stages, Conditional = s => s.B};
+            var conditionalC = new TestConditionNode {Print="C0", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
 
@@ -348,12 +348,12 @@ namespace Yggdrasil.Tests
         public void ParallelNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Parallel{Manager = manager};
+            var root = new Parallel();
             var stages = new Queue<string>();
 
-            var conditionalA = new TestYieldConditionNode(manager) {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
-            var conditionalB = new TestYieldConditionNode(manager) {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
-            var conditionalC = new TestYieldConditionNode(manager) {PrintA="CYield", PrintB="C", Stages = stages, Conditional = s => s.C};
+            var conditionalA = new TestYieldConditionNode {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
+            var conditionalC = new TestYieldConditionNode {PrintA="CYield", PrintB="C", Stages = stages, Conditional = s => s.C};
 
             root.Children = new List<Node> {conditionalA, conditionalB, conditionalC};
             manager.Root = root;
@@ -422,11 +422,11 @@ namespace Yggdrasil.Tests
         public void ParallelFilterNodeTest()
         {
             var manager = new CoroutineManager();
-            var root = new Interrupt(s => ((State)s).C){Manager = manager};
+            var root = new Interrupt(s => ((State)s).C);
             var stages = new Queue<string>();
 
-            var conditionalA = new TestYieldConditionNode(manager) {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
-            var conditionalB = new TestYieldConditionNode(manager) {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
+            var conditionalA = new TestYieldConditionNode {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
             
             root.Children = new List<Node> {conditionalA, conditionalB};
             manager.Root = root;
@@ -488,18 +488,18 @@ namespace Yggdrasil.Tests
             var manager = new CoroutineManager();
             var stages = new Queue<string>();
 
-            var parallelA = new Parallel{Manager = manager};
-            var parallelB = new Parallel{Manager = manager};
-            var parallelC = new Parallel{Manager = manager};
+            var parallelA = new Parallel();
+            var parallelB = new Parallel();
+            var parallelC = new Parallel();
 
-            var root = new Sequence{Manager = manager};
-            var entryCondition = new Condition(s => ((State) s).Entry){Manager = manager};
+            var root = new Sequence();
+            var entryCondition = new Condition(s => ((State) s).Entry);
 
-            var conditionalA = new TestYieldConditionNode(manager) {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
-            var conditionalB = new TestYieldConditionNode(manager) {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
-            var conditionalC = new TestYieldConditionNode(manager) {PrintA="CYield", PrintB="C", Stages = stages, Conditional = s => s.C};
-            var conditionalD = new TestYieldConditionNode(manager) {PrintA="DYield", PrintB="D", Stages = stages, Conditional = s => s.D};
-            var conditionalE = new TestRunningConditionNode(manager) {PrintA="E", Stages = stages, Conditional = s => s.E};
+            var conditionalA = new TestYieldConditionNode {PrintA="AYield", PrintB="A", Stages = stages, Conditional = s => s.A};
+            var conditionalB = new TestYieldConditionNode {PrintA="BYield", PrintB="B", Stages = stages, Conditional = s => s.B};
+            var conditionalC = new TestYieldConditionNode {PrintA="CYield", PrintB="C", Stages = stages, Conditional = s => s.C};
+            var conditionalD = new TestYieldConditionNode {PrintA="DYield", PrintB="D", Stages = stages, Conditional = s => s.D};
+            var conditionalE = new TestRunningConditionNode {PrintA="E", Stages = stages, Conditional = s => s.E};
 
             root.Children = new List<Node> {entryCondition, parallelA};
 
@@ -587,11 +587,6 @@ namespace Yggdrasil.Tests
 
             public Func<State, bool> Conditional;
 
-            public TestConditionNode(CoroutineManager manager)
-            {
-                Manager = manager;
-            }
-
             protected override Coroutine<Result> Tick()
             {
                 Stages.Enqueue(Print);
@@ -608,11 +603,6 @@ namespace Yggdrasil.Tests
             public Queue<string> Stages;
 
             public Func<State, bool> Conditional;
-
-            public TestYieldConditionNode(CoroutineManager manager)
-            {
-                Manager = manager;
-            }
 
             protected override async Coroutine<Result> Tick()
             {
@@ -636,11 +626,6 @@ namespace Yggdrasil.Tests
             public Queue<string> Stages;
 
             public Func<State, bool> Conditional;
-
-            public TestNestedConditionNode(CoroutineManager manager)
-            {
-                Manager = manager;
-            }
 
             protected override async Coroutine<Result> Tick()
             {
@@ -677,11 +662,6 @@ namespace Yggdrasil.Tests
             public Queue<string> Stages;
 
             public Func<State, bool> Conditional;
-
-            public TestRunningConditionNode(CoroutineManager manager)
-            {
-                Manager = manager;
-            }
 
             protected override async Coroutine<Result> Tick()
             {

--- a/Yggdrasil.Tests/ParserTests.cs
+++ b/Yggdrasil.Tests/ParserTests.cs
@@ -3,7 +3,7 @@ using System.Xml.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 using Yggdrasil.Scripting;
 
 namespace Yggdrasil.Tests

--- a/Yggdrasil.Tests/ParserTests.cs
+++ b/Yggdrasil.Tests/ParserTests.cs
@@ -68,7 +68,6 @@ namespace Yggdrasil.Tests
             config.NodeTypeAssemblies.Add(typeof(ParameterizedTestNode).Assembly.GetName().Name);
 
             var compiler = new YggCompiler();
-            var manager = new CoroutineManager();
             var parser = new YggParser(config, compiler);
             var context = parser.BuildFromFiles<TestState>("ParserTests\\testScriptA.ygg");
 
@@ -76,7 +75,7 @@ namespace Yggdrasil.Tests
             Assert.AreEqual(4, context.TopmostNodeCount);
 
             // MyCustomTypeA
-            var nodeA = context.Instantiate("A", manager);
+            var nodeA = context.Instantiate("A");
             Assert.AreEqual("A", nodeA.Guid);
             Assert.AreEqual(typeof(Filter), nodeA.GetType());
             Assert.AreEqual(1, nodeA.Children.Count);
@@ -107,7 +106,7 @@ namespace Yggdrasil.Tests
             Assert.AreEqual(0, nodeF.Children.Count);
 
             // MyCustomTypeB
-            var nodeG = context.Instantiate("G", manager);
+            var nodeG = context.Instantiate("G");
             Assert.AreEqual("G", nodeG.Guid);
             Assert.AreEqual(typeof(Sequence), nodeG.GetType());
             Assert.AreEqual(2, nodeG.Children.Count);
@@ -123,7 +122,7 @@ namespace Yggdrasil.Tests
             CheckMyCustomTypeA(nodeI);
 
             // Third node.
-            var nodeJ = context.Instantiate("J", manager);
+            var nodeJ = context.Instantiate("J");
             Assert.AreEqual("J", nodeJ.Guid);
             Assert.AreEqual(typeof(Inverter), nodeJ.GetType());
             Assert.AreEqual(1, nodeJ.Children.Count);
@@ -134,7 +133,7 @@ namespace Yggdrasil.Tests
             CheckMyCustomTypeB(nodeK);
 
             // Parameterized node.
-            var nodeL = context.Instantiate("L", manager);
+            var nodeL = context.Instantiate("L");
             Assert.AreEqual("L", nodeL.Guid);
             Assert.AreEqual(typeof(ParameterizedTestNode), nodeL.GetType());
             Assert.AreEqual(7, nodeL.Children.Count);

--- a/Yggdrasil.Tests/TreeTests.cs
+++ b/Yggdrasil.Tests/TreeTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Yggdrasil.Attributes;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 using Yggdrasil.Scripting;
 
 namespace Yggdrasil.Tests

--- a/Yggdrasil.Tests/TreeTests.cs
+++ b/Yggdrasil.Tests/TreeTests.cs
@@ -24,17 +24,16 @@ namespace Yggdrasil.Tests
             config.NodeTypeAssemblies.Add(typeof(TestRunningAction).Assembly.GetName().Name);
 
             var compiler = new YggCompiler();
-            var manager = new CoroutineManager();
             var parser = new YggParser(config, compiler);
             var context = parser.BuildFromFiles<TestState>("ParserTests\\testScriptB.ygg");
 
             Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual(3, context.TopmostNodeCount);
 
-            var root = context.Instantiate("root", manager);
+            var root = context.Instantiate("root");
             Assert.IsNotNull(root);
 
-            manager.Root = root;
+            var manager = new BehaviourTree(root);
             AssertScriptB(manager);
 
             manager.Reset();
@@ -51,7 +50,6 @@ namespace Yggdrasil.Tests
             config.NodeTypeAssemblies.Add(typeof(TestRunningAction).Assembly.GetName().Name);
 
             var compiler = new YggCompiler();
-            var manager = new CoroutineManager();
             var parser = new YggParser(config, compiler);
 
             for (var i = 0; i < 5; i++)
@@ -61,10 +59,10 @@ namespace Yggdrasil.Tests
                 Assert.AreEqual(0, context.Errors.Count);
                 Assert.AreEqual(3, context.TopmostNodeCount);
 
-                var root = context.Instantiate("root", manager);
+                var root = context.Instantiate("root");
                 Assert.IsNotNull(root);
 
-                manager.Root = root;
+                var manager = new BehaviourTree(root);
                 AssertScriptB(manager);
             }
         }
@@ -147,19 +145,18 @@ namespace Yggdrasil.Tests
             config.NodeTypeAssemblies.Add(typeof(TestDynamicFunction).Assembly.GetName().Name);
 
             var compiler = new YggCompiler();
-            var manager = new CoroutineManager();
             var parser = new YggParser(config, compiler);
             var context = parser.BuildFromFiles<object>("ParserTests\\testScriptC.ygg");
 
             Assert.AreEqual(0, context.Errors.Count);
             Assert.AreEqual(1, context.TopmostNodeCount);
 
-            var root = context.Instantiate("root", manager);
+            var root = context.Instantiate("root");
             Assert.IsNotNull(root);
 
             dynamic state = new ExpandoObject();
 
-            manager.Root = root;
+            var manager = new BehaviourTree(root);
             manager.Update(state);
 
             Assert.AreEqual(1UL, manager.TickCount);
@@ -167,7 +164,7 @@ namespace Yggdrasil.Tests
             Assert.AreEqual(1, state.A);
         }
 
-        private static void AssertScriptB(CoroutineManager manager)
+        private static void AssertScriptB(BehaviourTree manager)
         {
             var state = new TestState();
 

--- a/Yggdrasil/Behaviour/BehaviourTree.cs
+++ b/Yggdrasil/Behaviour/BehaviourTree.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using Yggdrasil.Coroutines;
+using Yggdrasil.Enums;
+
+namespace Yggdrasil.Behaviour
+{
+    public class BehaviourTree
+    {
+        [ThreadStatic]
+        internal static BehaviourTree CurrentInstance;
+
+        private readonly CoroutineManager _manager;
+
+        private readonly Dictionary<CoroutineThread, Stack<Node>> _providersMap =
+            new Dictionary<CoroutineThread, Stack<Node>>();
+
+        internal readonly Coroutine Yield;
+        internal readonly Coroutine<Result> Success;
+        internal readonly Coroutine<Result> Failure;
+
+        public BehaviourTree(Node root)
+        {
+            Root = root;
+
+            Yield = Coroutine.CreateConst(false);
+            Success = Coroutine<Result>.CreateConst(Result.Success);
+            Failure = Coroutine<Result>.CreateConst(Result.Failure);
+
+            _manager = new CoroutineManager();
+        }
+
+        public Node Root { get; }
+
+        public event EventHandler<Node> NodeActiveEventHandler;
+
+        public event EventHandler<Node> NodeInactiveEventHandler;
+
+        public object State { get; private set; }
+
+        public ulong Ticks { get; private set; }
+
+        public void Update(object state)
+        {
+            if (Root == null) { return; }
+
+            CurrentInstance = this;
+            State = state;
+        }
+
+        public void Reset()
+        {
+            _manager.Reset();
+
+            Ticks = 0;
+            State = null;
+        }
+
+        internal void OnNodeTickStarted(Node node)
+        {
+            if (!_providersMap.TryGetValue(_manager.ActiveThread, out var providers))
+            {
+                providers = new Stack<Node>();
+                _providersMap[_manager.ActiveThread] = providers;
+            }
+
+            providers.Push(node);
+            OnNodeActiveEvent(node);
+        }
+
+        internal void OnNodeTickFinished(Node node)
+        {
+            if (!_providersMap.TryGetValue(_manager.ActiveThread, out var providers))
+            {
+                providers = new Stack<Node>();
+                _providersMap[_manager.ActiveThread] = providers;
+            }
+
+            providers.Pop();
+            OnNodeInactiveEvent(node);
+        }
+
+        internal void ProcessThread(CoroutineThread thread)
+        {
+            _manager.ProcessThread(thread);
+        }
+
+        internal void ProcessThreadAsDependency(CoroutineThread thread)
+        {
+            _manager.ProcessThreadAsDependency(thread);
+        }
+
+        internal void TerminateThread(CoroutineThread thread)
+        {
+            if (_providersMap.TryGetValue(thread, out var nodes))
+            {
+                foreach (var node in nodes) { node.Terminate(); }
+                nodes.Clear();
+            }
+
+            _manager.TerminateThread(thread);
+        }
+
+        protected virtual void OnNodeActiveEvent(Node node)
+        {
+            var handler = NodeActiveEventHandler;
+            handler?.Invoke(this, node);
+        }
+
+        protected virtual void OnNodeInactiveEvent(Node node)
+        {
+            var handler = NodeInactiveEventHandler;
+            handler?.Invoke(this, node);
+        }
+    }
+}

--- a/Yggdrasil/Behaviour/BehaviourTree.cs
+++ b/Yggdrasil/Behaviour/BehaviourTree.cs
@@ -12,8 +12,8 @@ namespace Yggdrasil.Behaviour
 
         private readonly CoroutineManager _manager;
 
-        private readonly Dictionary<CoroutineThread, Stack<Node>> _providersMap =
-            new Dictionary<CoroutineThread, Stack<Node>>();
+        private readonly Dictionary<CoroutineThread<Result>, Stack<Node>> _providersMap =
+            new Dictionary<CoroutineThread<Result>, Stack<Node>>();
 
         internal Coroutine Yield => _manager.Yield;
         internal readonly Coroutine<Result> Success;
@@ -95,17 +95,17 @@ namespace Yggdrasil.Behaviour
             OnNodeInactiveEvent(node);
         }
 
-        internal void ProcessThread(CoroutineThread thread)
+        internal void ProcessThread(CoroutineThread<Result> thread)
         {
             _manager.ProcessThread(thread);
         }
 
-        internal void ProcessThreadAsDependency(CoroutineThread thread)
+        internal void ProcessThreadAsDependency(CoroutineThread<Result> thread)
         {
             _manager.ProcessThreadAsDependency(thread);
         }
 
-        internal void TerminateThread(CoroutineThread thread)
+        internal void TerminateThread(CoroutineThread<Result> thread)
         {
             if (_providersMap.TryGetValue(thread, out var nodes))
             {

--- a/Yggdrasil/Behaviour/BehaviourTree.cs
+++ b/Yggdrasil/Behaviour/BehaviourTree.cs
@@ -10,7 +10,7 @@ namespace Yggdrasil.Behaviour
         [ThreadStatic]
         internal static BehaviourTree CurrentInstance;
 
-        private readonly CoroutineManager _manager;
+        private readonly CoroutineManager<Result> _manager;
 
         private readonly Dictionary<CoroutineThread<Result>, Stack<Node>> _providersMap =
             new Dictionary<CoroutineThread<Result>, Stack<Node>>();
@@ -26,8 +26,8 @@ namespace Yggdrasil.Behaviour
             Success = Coroutine<Result>.CreateConst(Result.Success);
             Failure = Coroutine<Result>.CreateConst(Result.Failure);
 
-            _manager = new CoroutineManager();
-            _manager.Root = root;
+            _manager = new CoroutineManager<Result>();
+            _manager.Root = root.Execute;
         }
 
         public Node Root { get; }
@@ -40,16 +40,7 @@ namespace Yggdrasil.Behaviour
 
         public ulong TickCount => _manager.TickCount;
 
-        public Result Result
-        {
-            get
-            {
-                var result = _manager.Result;
-                if (result == null) { return Result.Unknown; }
-
-                return (Result) result;
-            }
-        }
+        public Result Result => _manager.Result;
 
         public void Update(object state = null)
         {

--- a/Yggdrasil/Behaviour/BehaviourTree.cs
+++ b/Yggdrasil/Behaviour/BehaviourTree.cs
@@ -15,7 +15,7 @@ namespace Yggdrasil.Behaviour
         private readonly Dictionary<CoroutineThread, Stack<Node>> _providersMap =
             new Dictionary<CoroutineThread, Stack<Node>>();
 
-        internal readonly Coroutine Yield;
+        internal Coroutine Yield => _manager.Yield;
         internal readonly Coroutine<Result> Success;
         internal readonly Coroutine<Result> Failure;
 
@@ -23,11 +23,11 @@ namespace Yggdrasil.Behaviour
         {
             Root = root;
 
-            Yield = Coroutine.CreateConst(false);
             Success = Coroutine<Result>.CreateConst(Result.Success);
             Failure = Coroutine<Result>.CreateConst(Result.Failure);
 
             _manager = new CoroutineManager();
+            _manager.Root = root;
         }
 
         public Node Root { get; }
@@ -38,21 +38,27 @@ namespace Yggdrasil.Behaviour
 
         public object State { get; private set; }
 
-        public ulong Ticks { get; private set; }
+        public ulong TickCount => _manager.TickCount;
 
-        public void Update(object state)
+        public Result Result => _manager.Result;
+
+        public void Update(object state = null)
         {
             if (Root == null) { return; }
 
             CurrentInstance = this;
             State = state;
+
+            _manager.Update();
+
+            State = null;
+            CurrentInstance = null;
         }
 
         public void Reset()
         {
             _manager.Reset();
 
-            Ticks = 0;
             State = null;
         }
 

--- a/Yggdrasil/Behaviour/BehaviourTree.cs
+++ b/Yggdrasil/Behaviour/BehaviourTree.cs
@@ -104,7 +104,7 @@ namespace Yggdrasil.Behaviour
                 nodes.Clear();
             }
 
-            _manager.TerminateThread(thread);
+            _manager.TerminateThreadAndDependencies(thread);
         }
 
         protected virtual void OnNodeActiveEvent(Node node)

--- a/Yggdrasil/Behaviour/BehaviourTree.cs
+++ b/Yggdrasil/Behaviour/BehaviourTree.cs
@@ -40,7 +40,16 @@ namespace Yggdrasil.Behaviour
 
         public ulong TickCount => _manager.TickCount;
 
-        public Result Result => _manager.Result;
+        public Result Result
+        {
+            get
+            {
+                var result = _manager.Result;
+                if (result == null) { return Result.Unknown; }
+
+                return (Result) result;
+            }
+        }
 
         public void Update(object state = null)
         {

--- a/Yggdrasil/Behaviour/Condition.cs
+++ b/Yggdrasil/Behaviour/Condition.cs
@@ -33,39 +33,24 @@ using Yggdrasil.Attributes;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
 
-namespace Yggdrasil.Nodes
+namespace Yggdrasil.Behaviour
 {
-    public class Filter : Node
+    public class Condition : Node
     {
-        public Filter(Func<object, bool> conditional)
+        public Condition(Func<object, bool> conditional)
         {
             Conditional = conditional;
         }
 
-        public Filter() { }
-
-        [XmlIgnore]
-        public Node Child
-        {
-            get
-            {
-                if (Children == null || Children.Count <= 0) { return null; }
-
-                return Children[0];
-            }
-        }
+        public Condition() { }
 
         [XmlIgnore]
         [ScriptedFunction]
         public Func<object, bool> Conditional { get; set; } = DefaultConditional;
 
-        protected override async Coroutine<Result> Tick()
+        protected override Coroutine<Result> Tick()
         {
-            if (Child == null) { return Result.Failure; }
-
-            if (!Conditional(State)) { return Result.Failure; }
-
-            return await Child.Execute();
+            return Conditional(State) ? Success : Failure;
         }
 
         private static bool DefaultConditional(object s)

--- a/Yggdrasil/Behaviour/Filter.cs
+++ b/Yggdrasil/Behaviour/Filter.cs
@@ -27,24 +27,50 @@
 
 #endregion
 
+using System;
+using System.Xml.Serialization;
+using Yggdrasil.Attributes;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
 
-namespace Yggdrasil.Nodes
+namespace Yggdrasil.Behaviour
 {
-    public class Selector : Node
+    public class Filter : Node
     {
+        public Filter(Func<object, bool> conditional)
+        {
+            Conditional = conditional;
+        }
+
+        public Filter() { }
+
+        [XmlIgnore]
+        public Node Child
+        {
+            get
+            {
+                if (Children == null || Children.Count <= 0) { return null; }
+
+                return Children[0];
+            }
+        }
+
+        [XmlIgnore]
+        [ScriptedFunction]
+        public Func<object, bool> Conditional { get; set; } = DefaultConditional;
+
         protected override async Coroutine<Result> Tick()
         {
-            if (Children == null || Children.Count <= 0) { return Result.Failure; }
+            if (Child == null) { return Result.Failure; }
 
-            foreach (var child in Children)
-            {
-                var result = await child.Execute();
-                if (result == Result.Success) { return result; }
-            }
+            if (!Conditional(State)) { return Result.Failure; }
 
-            return Result.Failure;
+            return await Child.Execute();
+        }
+
+        private static bool DefaultConditional(object s)
+        {
+            return true;
         }
     }
 }

--- a/Yggdrasil/Behaviour/Interrupt.cs
+++ b/Yggdrasil/Behaviour/Interrupt.cs
@@ -39,7 +39,7 @@ namespace Yggdrasil.Behaviour
     public class Interrupt : Node
     {
         [XmlIgnore]
-        private readonly List<CoroutineThread> _threads = new List<CoroutineThread>(10);
+        private readonly List<CoroutineThread<Result>> _threads = new List<CoroutineThread<Result>>(10);
 
         public Interrupt(Func<object, bool> conditional)
         {
@@ -63,7 +63,7 @@ namespace Yggdrasil.Behaviour
             {
                 foreach (var n in Children)
                 {
-                    var thread = new CoroutineThread(n.Execute, false, 1);
+                    var thread = new CoroutineThread<Result>(n.Execute, false, 1);
                     _threads.Add(thread);
                 }
             }
@@ -95,8 +95,7 @@ namespace Yggdrasil.Behaviour
 
             foreach (var thread in _threads)
             {
-                var r = thread.Result;
-                if (r != null && ((Result)r) == Result.Success) { result = Result.Success; }
+                if (thread.Result == Result.Success) { result = Result.Success; }
 
                 thread.Reset();
             }

--- a/Yggdrasil/Behaviour/Interrupt.cs
+++ b/Yggdrasil/Behaviour/Interrupt.cs
@@ -63,7 +63,7 @@ namespace Yggdrasil.Behaviour
             {
                 foreach (var n in Children)
                 {
-                    var thread = new CoroutineThread(n, false, 1);
+                    var thread = new CoroutineThread(n.Execute, false, 1);
                     _threads.Add(thread);
                 }
             }
@@ -95,7 +95,8 @@ namespace Yggdrasil.Behaviour
 
             foreach (var thread in _threads)
             {
-                if (thread.Result == Result.Success) { result = Result.Success; }
+                var r = thread.Result;
+                if (r != null && ((Result)r) == Result.Success) { result = Result.Success; }
 
                 thread.Reset();
             }

--- a/Yggdrasil/Behaviour/Inverter.cs
+++ b/Yggdrasil/Behaviour/Inverter.cs
@@ -27,24 +27,33 @@
 
 #endregion
 
+using System.Xml.Serialization;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
 
-namespace Yggdrasil.Nodes
+namespace Yggdrasil.Behaviour
 {
-    public class Sequence : Node
+    public class Inverter : Node
     {
+        [XmlIgnore]
+        public Node Child
+        {
+            get
+            {
+                if (Children == null || Children.Count <= 0) { return null; }
+
+                return Children[0];
+            }
+        }
+
         protected override async Coroutine<Result> Tick()
         {
-            if (Children == null || Children.Count <= 0) { return Result.Failure; }
+            if (Child == null) { return Result.Failure; }
 
-            foreach (var child in Children)
-            {
-                var result = await child.Execute();
-                if (result == Result.Failure) { return result; }
-            }
+            var result = await Child.Execute();
+            if (result == Result.Unknown) { return result; }
 
-            return Result.Success;
+            return result == Result.Success ? Result.Failure : Result.Success;
         }
     }
 }

--- a/Yggdrasil/Behaviour/Node.cs
+++ b/Yggdrasil/Behaviour/Node.cs
@@ -57,6 +57,21 @@ namespace Yggdrasil.Behaviour
         [XmlIgnore]
         public string Guid { get; set; }
 
+        public IEnumerable<Node> DepthFirstIterate()
+        {
+            var open = new Stack<Node>();
+            open.Push(this);
+
+            while (open.Count > 0)
+            {
+                var next = open.Pop();
+                yield return next;
+
+                if (next.Children == null) { continue; }
+                foreach (var c in next.Children) { open.Push(c); }
+            }
+        }
+
         public async Coroutine<Result> Execute()
         {
             BehaviourTree.CurrentInstance.OnNodeTickStarted(this);

--- a/Yggdrasil/Behaviour/Parallel.cs
+++ b/Yggdrasil/Behaviour/Parallel.cs
@@ -50,7 +50,7 @@ namespace Yggdrasil.Behaviour
             {
                 foreach (var n in Children)
                 {
-                    var thread = new CoroutineThread(n, false, 1);
+                    var thread = new CoroutineThread(n.Execute, false, 1);
                     _threads.Add(thread);
                 }
             }
@@ -66,7 +66,8 @@ namespace Yggdrasil.Behaviour
 
             foreach (var thread in _threads)
             {
-                if (thread.Result == Result.Success) { result = Result.Success; }
+                var r = thread.Result;
+                if (r != null && ((Result)r) == Result.Success) { result = Result.Success; }
 
                 thread.Reset();
             }

--- a/Yggdrasil/Behaviour/Parallel.cs
+++ b/Yggdrasil/Behaviour/Parallel.cs
@@ -37,7 +37,7 @@ namespace Yggdrasil.Behaviour
     public class Parallel : Node
     {
         [XmlIgnore]
-        private readonly List<CoroutineThread> _threads = new List<CoroutineThread>(10);
+        private readonly List<CoroutineThread<Result>> _threads = new List<CoroutineThread<Result>>(10);
 
         public override void Terminate()
         {
@@ -50,7 +50,7 @@ namespace Yggdrasil.Behaviour
             {
                 foreach (var n in Children)
                 {
-                    var thread = new CoroutineThread(n.Execute, false, 1);
+                    var thread = new CoroutineThread<Result>(n.Execute, false, 1);
                     _threads.Add(thread);
                 }
             }
@@ -66,8 +66,7 @@ namespace Yggdrasil.Behaviour
 
             foreach (var thread in _threads)
             {
-                var r = thread.Result;
-                if (r != null && ((Result)r) == Result.Success) { result = Result.Success; }
+                if (thread.Result == Result.Success) { result = Result.Success; }
 
                 thread.Reset();
             }

--- a/Yggdrasil/Behaviour/Selector.cs
+++ b/Yggdrasil/Behaviour/Selector.cs
@@ -27,30 +27,24 @@
 
 #endregion
 
-using System;
-using System.Xml.Serialization;
-using Yggdrasil.Attributes;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
 
-namespace Yggdrasil.Nodes
+namespace Yggdrasil.Behaviour
 {
-    public class Leaf : Node
+    public class Selector : Node
     {
-        [XmlAttribute]
-        public Result Output { get; set; }
-
-        [XmlIgnore]
-        [ScriptedFunction]
-        public Action<object> Function { get; set; } = DefaultFunction;
-
-        protected override Coroutine<Result> Tick()
+        protected override async Coroutine<Result> Tick()
         {
-            Function(State);
+            if (Children == null || Children.Count <= 0) { return Result.Failure; }
 
-            return Output == Result.Success ? Success : Failure;
+            foreach (var child in Children)
+            {
+                var result = await child.Execute();
+                if (result == Result.Success) { return result; }
+            }
+
+            return Result.Failure;
         }
-
-        private static void DefaultFunction(object state) { }
     }
 }

--- a/Yggdrasil/Behaviour/Sequence.cs
+++ b/Yggdrasil/Behaviour/Sequence.cs
@@ -27,35 +27,24 @@
 
 #endregion
 
-using System;
-using System.Xml.Serialization;
-using Yggdrasil.Attributes;
 using Yggdrasil.Coroutines;
 using Yggdrasil.Enums;
 
-namespace Yggdrasil.Nodes
+namespace Yggdrasil.Behaviour
 {
-    public class Condition : Node
+    public class Sequence : Node
     {
-        public Condition(Func<object, bool> conditional)
+        protected override async Coroutine<Result> Tick()
         {
-            Conditional = conditional;
-        }
+            if (Children == null || Children.Count <= 0) { return Result.Failure; }
 
-        public Condition() { }
+            foreach (var child in Children)
+            {
+                var result = await child.Execute();
+                if (result == Result.Failure) { return result; }
+            }
 
-        [XmlIgnore]
-        [ScriptedFunction]
-        public Func<object, bool> Conditional { get; set; } = DefaultConditional;
-
-        protected override Coroutine<Result> Tick()
-        {
-            return Conditional(State) ? Success : Failure;
-        }
-
-        private static bool DefaultConditional(object s)
-        {
-            return true;
+            return Result.Success;
         }
     }
 }

--- a/Yggdrasil/Coroutines/Coroutine.cs
+++ b/Yggdrasil/Coroutines/Coroutine.cs
@@ -103,6 +103,19 @@ namespace Yggdrasil.Coroutines
             return result;
         }
 
+        public override object GetThreadResult()
+        {
+            if (_isConstant) { return _result; }
+
+            var result = _result;
+
+            _result = default;
+            IsCompleted = false;
+            _pool.Recycle(this);
+
+            return result;
+        }
+
         public void SetResult(T result)
         {
             _result = result;
@@ -256,6 +269,16 @@ namespace Yggdrasil.Coroutines
             where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine
         {
             CoroutineManager.CurrentInstance.AddContinuation(this);
+        }
+
+        public override object GetThreadResult()
+        {
+            if (_isConstant) { return null; }
+
+            IsCompleted = false;
+            _pool.Recycle(this);
+
+            return null;
         }
     }
 }

--- a/Yggdrasil/Coroutines/Coroutine.cs
+++ b/Yggdrasil/Coroutines/Coroutine.cs
@@ -36,7 +36,7 @@ namespace Yggdrasil.Coroutines
     [AsyncMethodBuilder(typeof(Coroutine<>))]
     public class Coroutine<T> : CoroutineBase, ICriticalNotifyCompletion, IContinuation
     {
-        private static readonly ConcurrentPool<Coroutine<T>> _pool = new ConcurrentPool<Coroutine<T>>();
+        public static readonly ConcurrentPool<Coroutine<T>> Pool = new ConcurrentPool<Coroutine<T>>();
 
         private bool _isConstant;
         private T _result;
@@ -62,7 +62,7 @@ namespace Yggdrasil.Coroutines
 
             _stateMachine = null;
 
-            _pool.Recycle(this);
+            Pool.Recycle(this);
         }
 
         public void OnCompleted(Action continuation) { }
@@ -71,12 +71,12 @@ namespace Yggdrasil.Coroutines
 
         public static Coroutine<T> Create()
         {
-            return _pool.Get();
+            return Pool.Get();
         }
 
         public static Coroutine<T> CreateConst(T result)
         {
-            var coroutine = _pool.Get();
+            var coroutine = Pool.Get();
 
             coroutine._result = result;
             coroutine.IsCompleted = true;
@@ -98,7 +98,7 @@ namespace Yggdrasil.Coroutines
 
             _result = default;
             IsCompleted = false;
-            _pool.Recycle(this);
+            Pool.Recycle(this);
 
             return result;
         }
@@ -151,7 +151,7 @@ namespace Yggdrasil.Coroutines
     [AsyncMethodBuilder(typeof(Coroutine))]
     public class Coroutine : CoroutineBase, ICriticalNotifyCompletion, IContinuation
     {
-        private static readonly ConcurrentPool<Coroutine> _pool = new ConcurrentPool<Coroutine>();
+        public static readonly ConcurrentPool<Coroutine> Pool = new ConcurrentPool<Coroutine>();
 
         private bool _isConstant;
         private IStateMachineWrapper _stateMachine;
@@ -175,7 +175,7 @@ namespace Yggdrasil.Coroutines
 
             _stateMachine = null;
 
-            _pool.Recycle(this);
+            Pool.Recycle(this);
         }
 
         public void OnCompleted(Action continuation) { }
@@ -184,12 +184,12 @@ namespace Yggdrasil.Coroutines
 
         public static Coroutine Create()
         {
-            return _pool.Get();
+            return Pool.Get();
         }
 
         public static Coroutine CreateConst(bool isCompleted)
         {
-            var coroutine = _pool.Get();
+            var coroutine = Pool.Get();
 
             coroutine.IsCompleted = isCompleted;
             coroutine._isConstant = true;
@@ -207,7 +207,7 @@ namespace Yggdrasil.Coroutines
             if (_isConstant) { return null; }
 
             IsCompleted = false;
-            _pool.Recycle(this);
+            Pool.Recycle(this);
 
             return null;
         }

--- a/Yggdrasil/Coroutines/Coroutine.cs
+++ b/Yggdrasil/Coroutines/Coroutine.cs
@@ -103,19 +103,6 @@ namespace Yggdrasil.Coroutines
             return result;
         }
 
-        public override object GetThreadResult()
-        {
-            if (_isConstant) { return _result; }
-
-            var result = _result;
-
-            _result = default;
-            IsCompleted = false;
-            _pool.Recycle(this);
-
-            return result;
-        }
-
         public void SetResult(T result)
         {
             _result = result;
@@ -132,7 +119,7 @@ namespace Yggdrasil.Coroutines
 
             _stateMachine = null;
 
-            CoroutineManager.CurrentInstance.SetException(exception);
+            CoroutineManagerBase.CurrentInstance.SetException(exception);
         }
 
         public void SetStateMachine(IAsyncStateMachine stateMachine) { }
@@ -150,14 +137,14 @@ namespace Yggdrasil.Coroutines
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter _, ref TStateMachine stateMachine)
             where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine
         {
-            CoroutineManager.CurrentInstance.AddContinuation(this);
+            CoroutineManagerBase.CurrentInstance.AddContinuation(this);
         }
 
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter _,
             ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine
         {
-            CoroutineManager.CurrentInstance.AddContinuation(this);
+            CoroutineManagerBase.CurrentInstance.AddContinuation(this);
         }
     }
 
@@ -243,7 +230,7 @@ namespace Yggdrasil.Coroutines
 
             _stateMachine = null;
 
-            CoroutineManager.CurrentInstance.SetException(exception);
+            CoroutineManagerBase.CurrentInstance.SetException(exception);
         }
 
         public void SetStateMachine(IAsyncStateMachine stateMachine) { }
@@ -261,24 +248,14 @@ namespace Yggdrasil.Coroutines
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine
         {
-            CoroutineManager.CurrentInstance.AddContinuation(this);
+            CoroutineManagerBase.CurrentInstance.AddContinuation(this);
         }
 
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter,
             ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine
         {
-            CoroutineManager.CurrentInstance.AddContinuation(this);
-        }
-
-        public override object GetThreadResult()
-        {
-            if (_isConstant) { return null; }
-
-            IsCompleted = false;
-            _pool.Recycle(this);
-
-            return null;
+            CoroutineManagerBase.CurrentInstance.AddContinuation(this);
         }
     }
 }

--- a/Yggdrasil/Coroutines/CoroutineBase.cs
+++ b/Yggdrasil/Coroutines/CoroutineBase.cs
@@ -35,5 +35,7 @@ namespace Yggdrasil.Coroutines
     {
         internal static readonly ConcurrentPoolMap<IStateMachineWrapper> SmPool =
             new ConcurrentPoolMap<IStateMachineWrapper>();
+
+        public abstract object GetThreadResult();
     }
 }

--- a/Yggdrasil/Coroutines/CoroutineBase.cs
+++ b/Yggdrasil/Coroutines/CoroutineBase.cs
@@ -35,7 +35,5 @@ namespace Yggdrasil.Coroutines
     {
         internal static readonly ConcurrentPoolMap<IStateMachineWrapper> SmPool =
             new ConcurrentPoolMap<IStateMachineWrapper>();
-
-        public abstract object GetThreadResult();
     }
 }

--- a/Yggdrasil/Coroutines/CoroutineManager.cs
+++ b/Yggdrasil/Coroutines/CoroutineManager.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Yggdrasil.Coroutines
 {

--- a/Yggdrasil/Coroutines/CoroutineManager.cs
+++ b/Yggdrasil/Coroutines/CoroutineManager.cs
@@ -40,13 +40,13 @@ namespace Yggdrasil.Coroutines
         [ThreadStatic]
         internal static CoroutineManager CurrentInstance;
 
-        private readonly Stack<CoroutineThread> _iterationOpenSet = new Stack<CoroutineThread>(100);
-        private readonly Stack<CoroutineThread> _iterationReverseSet = new Stack<CoroutineThread>(100);
-        private readonly List<CoroutineThread> _threads = new List<CoroutineThread>(100);
+        private readonly Stack<CoroutineThread<Result>> _iterationOpenSet = new Stack<CoroutineThread<Result>>(100);
+        private readonly Stack<CoroutineThread<Result>> _iterationReverseSet = new Stack<CoroutineThread<Result>>(100);
+        private readonly List<CoroutineThread<Result>> _threads = new List<CoroutineThread<Result>>(100);
 
         internal readonly Coroutine Yield;
         private int _activeThreadIndex;
-        private CoroutineThread _mainThread;
+        private CoroutineThread<Result> _mainThread;
 
         private Node _root;
 
@@ -65,12 +65,12 @@ namespace Yggdrasil.Coroutines
             set
             {
                 _root = value;
-                _mainThread = new CoroutineThread(_root.Execute, true, 0);
+                _mainThread = new CoroutineThread<Result>(_root.Execute, true, 0);
                 Reset();
             }
         }
 
-        public CoroutineThread ActiveThread { get; private set; }
+        public CoroutineThread<Result> ActiveThread { get; private set; }
 
         public void Update()
         {
@@ -145,12 +145,12 @@ namespace Yggdrasil.Coroutines
             throw exception;
         }
 
-        internal void ProcessThread(CoroutineThread thread)
+        internal void ProcessThread(CoroutineThread<Result> thread)
         {
             _threads.Add(thread);
         }
 
-        internal void ProcessThreadAsDependency(CoroutineThread thread)
+        internal void ProcessThreadAsDependency(CoroutineThread<Result> thread)
         {
             _threads.Add(thread);
             thread.OutputDependencies.Add(ActiveThread);
@@ -159,7 +159,7 @@ namespace Yggdrasil.Coroutines
             ActiveThread.DependenciesFinished = false;
         }
 
-        internal void TerminateThreadAndDependencies(CoroutineThread thread)
+        internal void TerminateThreadAndDependencies(CoroutineThread<Result> thread)
         {
             // All threads below this one must also be terminated.
             // We iterate inbound dependencies from bottom up.

--- a/Yggdrasil/Coroutines/CoroutineManager.cs
+++ b/Yggdrasil/Coroutines/CoroutineManager.cs
@@ -57,7 +57,7 @@ namespace Yggdrasil.Coroutines
 
         public ulong TickCount => _mainThread?.TickCount ?? 0;
 
-        public Result Result => _mainThread?.Result ?? Result.Unknown;
+        public object Result => _mainThread?.Result;
 
         public Node Root
         {
@@ -65,7 +65,7 @@ namespace Yggdrasil.Coroutines
             set
             {
                 _root = value;
-                _mainThread = new CoroutineThread(value, true, 0);
+                _mainThread = new CoroutineThread(_root.Execute, true, 0);
                 Reset();
             }
         }

--- a/Yggdrasil/Coroutines/CoroutineManagerBase.cs
+++ b/Yggdrasil/Coroutines/CoroutineManagerBase.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Yggdrasil.Coroutines
+{
+    public abstract class CoroutineManagerBase
+    {
+        [ThreadStatic]
+        internal static CoroutineManagerBase CurrentInstance;
+
+        internal abstract void AddContinuation(IContinuation continuation);
+
+        internal abstract void SetException(Exception exception);
+    }
+}

--- a/Yggdrasil/Coroutines/CoroutineThread.cs
+++ b/Yggdrasil/Coroutines/CoroutineThread.cs
@@ -47,8 +47,10 @@ namespace Yggdrasil.Coroutines
             NeverCompletes = neverCompletes;
         }
 
+        // Outbound dependencies are those which need this thread to complete before they can complete.
         internal HashSet<CoroutineThread> OutputDependencies { get; } = new HashSet<CoroutineThread>();
 
+        // Inbound dependencies are those which this thread depends on to complete before itself can complete.
         internal HashSet<CoroutineThread> InputDependencies { get; } = new HashSet<CoroutineThread>();
 
         public Node Root { get; }

--- a/Yggdrasil/Coroutines/CoroutineThread.cs
+++ b/Yggdrasil/Coroutines/CoroutineThread.cs
@@ -29,13 +29,12 @@
 
 using System.Collections.Generic;
 using Yggdrasil.Enums;
-using Yggdrasil.Nodes;
+using Yggdrasil.Behaviour;
 
 namespace Yggdrasil.Coroutines
 {
     public class CoroutineThread
     {
-        private readonly Stack<Node> _active = new Stack<Node>(100);
         private readonly List<IContinuation> _continuations = new List<IContinuation>(100);
         private readonly Stack<IContinuation> _continuationsBuffer = new Stack<IContinuation>(100);
 
@@ -57,8 +56,6 @@ namespace Yggdrasil.Coroutines
         public ulong TicksToComplete { get; }
 
         public bool NeverCompletes { get; }
-
-        public IEnumerable<Node> ActiveNodes => _active;
 
         internal bool DependenciesFinished { get; set; }
 
@@ -100,14 +97,10 @@ namespace Yggdrasil.Coroutines
 
         public void Reset()
         {
-            foreach (var node in _active) { node.Terminate(); }
-
             IsRunning = false;
             TickCount = 0;
             IsComplete = false;
             Result = Result.Unknown;
-
-            _active.Clear();
 
             foreach (var cont in _continuations) { cont.Discard(); }
 
@@ -120,16 +113,6 @@ namespace Yggdrasil.Coroutines
             InputDependencies.Clear();
             OutputDependencies.Clear();
             DependenciesFinished = false;
-        }
-
-        internal void OnNodeTickStarted(Node node)
-        {
-            _active.Push(node);
-        }
-
-        internal void OnNodeTickFinished()
-        {
-            _active.Pop();
         }
 
         internal void AddContinuation(IContinuation continuation)


### PR DESCRIPTION
Refactored **CoroutineManager** and **CoroutineThread** to make them independent of **Node** in an attempt to separate behavior classes form coroutines themselves. This lets coroutines be used outside of the behavior tree implementation. A new **BehaviourTree** takes some of the responsibilities instead. 